### PR TITLE
Fixes try to Load TagCloseUp for Undefined families

### DIFF
--- a/src/fort/myrmidon/priv/TagCloseUp.cpp
+++ b/src/fort/myrmidon/priv/TagCloseUp.cpp
@@ -123,6 +123,9 @@ TagCloseUp::Lister::Lister(const fs::path & absoluteBaseDir,
 	, d_threshold(threshold)
 	, d_resolver(resolver)
 	, d_parsed(0) {
+	if ( f == tags::Family::Undefined ) {
+		throw std::invalid_argument("Cannot list for undefined family tag");
+	}
 	try {
 		LoadCache();
 	} catch (const std::exception & e) {

--- a/src/fort/myrmidon/priv/TagCloseUpUTest.cpp
+++ b/src/fort/myrmidon/priv/TagCloseUpUTest.cpp
@@ -128,7 +128,16 @@ TEST_F(TagCloseUpUTest,CanBeLoadedFromFiles) {
 		                return FrameReference("",0,Time());
 	                };
 
+
 	auto barAntDir = TestSetup::Basedir() / "bar.0000/ants";
+
+	EXPECT_THROW(TagCloseUp::Lister::Create(barAntDir,
+	                                        tags::Family::Undefined,
+	                                         80,
+	                                        resolver);,
+	             std::invalid_argument);
+
+
 	auto lister = TagCloseUp::Lister::Create(barAntDir,
 	                                         tags::Family::Tag36h11,
 	                                         80,

--- a/src/fort/studio/bridge/MeasurementBridge.cpp
+++ b/src/fort/studio/bridge/MeasurementBridge.cpp
@@ -182,7 +182,7 @@ void MeasurementBridge::startAll() {
 
 
 void MeasurementBridge::startOne(const fmp::TrackingDataDirectoryConstPtr & tdd) {
-	if ( !d_experiment ) {
+	if ( !d_experiment || d_experiment->Family() == fort::tags::Family::Undefined ) {
 		return;
 	}
 	if ( d_loaders.count(tdd->URI()) != 0 ) {

--- a/src/fort/studio/utest/ExperimentBridgeUTest.hpp
+++ b/src/fort/studio/utest/ExperimentBridgeUTest.hpp
@@ -8,9 +8,7 @@ namespace fmp = fort::myrmidon::priv;
 
 class ExperimentBridgeUTest : public ::testing::Test {
 protected:
-	static void SetUpTestSuite();
-	static void TearDownTestSuite();
+	void SetUp();
 
-	static fmp::Experiment::Ptr s_experiment;
-
+	fs::path pathExisting;
 };


### PR DESCRIPTION
Closes #61

There was an Issue where fort::myrmidon::priv::TagCloseUp::Lister
could be created for fort::tags::Family::Undefined that was leading to
future issue because of thrown c++ exception.

Now the exception is raised at the creation of the Loader.

Furthermore, when adding TDD before setting up a family, was starting
the loader task in the GUI for Undefined families... Now loader task
are spin up only if a valid Tag is defined.

All new behaviors are properly unite tested