### PR TITLE
Avoids deadlock on single core CPU

### DIFF
--- a/src/fort/studio/bridge/IdentifiedFrameConcurrentLoader.cpp
+++ b/src/fort/studio/bridge/IdentifiedFrameConcurrentLoader.cpp
@@ -100,7 +100,8 @@ void IdentifiedFrameConcurrentLoader::loadMovieSegment(const fmp::TrackingDataDi
 	abordFlag->store(false);
 
 	int maxThreadCount = QThreadPool::globalInstance()->maxThreadCount();
-	if ( maxThreadCount <= 0 ) {
+	if ( maxThreadCount < 2 ) {
+		qWarning() << "Increases the work thread to at least 2 from " << maxThreadCount;
 		maxThreadCount = 2;
 		// avoids deadlock on the global instance !!!
 		QThreadPool::globalInstance()->setMaxThreadCount(maxThreadCount);


### PR DESCRIPTION
IdentifiedFrameCOncurrentLoader needs at least two threads: One
reading the data and spawning workers and one worker thread computing the
data. If there is only one thread, it will deadlock.

Closes #65