### PR TITLE
Makes binding compiles on ubunutu 18.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_policy(SET CMP0048 NEW)
 
-project(fort-studio VERSION 0.5.0
+project(fort-studio VERSION 0.5.1
                     LANGUAGES C CXX)
 
 cmake_minimum_required(VERSION 3.11)

--- a/bindings/R/FortMyrmidon/DESCRIPTION
+++ b/bindings/R/FortMyrmidon/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FortMyrmidon
 Type: Package
 Title: R Bindings to the FORT myrmidon C++ API
-Version: 0.5.0
+Version: 0.5.1
 Date: 2020-07-08
 Author: Alexandre Tuleu
 Maintainer: Alexandre Tuleu <alexandre.tuleu.2005@polytechnique.org>

--- a/bindings/R/FortMyrmidon/src/queries.cpp
+++ b/bindings/R/FortMyrmidon/src/queries.cpp
@@ -558,13 +558,12 @@ SEXP fmQueryComputeAntInteractions(const CExperiment & experiment,
 	if ( reportLocalTrajectories == false ) {
 		storeInteractions =
 			[&](const AntInteraction::ConstPtr & interaction) {
-				auto smallerInteraction = std::make_shared<AntInteraction>(AntInteraction{
-					    .IDs = interaction->IDs,
-					    .Types = interaction->Types,
-					    .Start = interaction->Start,
-					    .End = interaction->End,
-					    .Space = interaction->Space,
-					});
+				auto smallerInteraction = std::make_shared<AntInteraction>();
+				smallerInteraction->IDs = interaction->IDs;
+				smallerInteraction->Types = interaction->Types;
+				smallerInteraction->Start = interaction->Start;
+				smallerInteraction->End = interaction->End;
+				smallerInteraction->Space = interaction->Space;
 
 				resInteractions.push_back(smallerInteraction);
 


### PR DESCRIPTION
Initializer object list are not yet supported in gcc 7.5.0